### PR TITLE
ci: switch to npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -16,7 +21,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
+
+      - name: Install latest npm
+        run: npm install -g npm@latest
 
       - uses: pnpm/action-setup@v4
         with:
@@ -26,8 +34,10 @@ jobs:
       - name: Build
         run: pnpm --filter @awesome-cdk/cdk-report-codepipeline-status-to-github run build
 
+      - name: Install semantic-release npm plugin
+        run: pnpm --filter @awesome-cdk/cdk-report-codepipeline-status-to-github exec npm install @semantic-release/npm@13.1.5
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm --filter @awesome-cdk/cdk-report-codepipeline-status-to-github exec npx semantic-release

--- a/packages/github-notifier-construct/package.json
+++ b/packages/github-notifier-construct/package.json
@@ -2,7 +2,8 @@
   "name": "@awesome-cdk/cdk-report-codepipeline-status-to-github",
   "version": "0.0.0",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Summary
- Replace long-lived `NPM_TOKEN` with GitHub Actions OIDC-based trusted publishing (no more 90-day token rotation)
- Bump Node.js to 22 and install `@semantic-release/npm@13.1.5` for OIDC support
- Add `provenance: true` to `publishConfig` for supply chain attestation

## Prerequisites
- npm package linked to this GitHub repo on npmjs.com (Trusted Publisher config) ✅

## Test plan
- [ ] Merge PR and verify the release workflow completes successfully
- [ ] Confirm the published package shows "Published with provenance" on npmjs.com